### PR TITLE
Update simulation initialization call

### DIFF
--- a/docs/src/component_models/freq_esti.md
+++ b/docs/src/component_models/freq_esti.md
@@ -23,7 +23,7 @@ of the respective angle ``\theta`` with respect to the grid SRF (instead of the 
 \dot{v}_{d,\text{pll}} &= \omega_{\text{lp}} \left [v_{d,\text{out}} - v_{d,\text{pll}} \right] \tag{1a} \\
 \dot{v}_{q,\text{pll}} &= \omega_{\text{lp}} \left [v_{q,\text{out}} - v_{q,\text{pll}} \right] \tag{1b} \\
 \dot{\varepsilon}_{\text{pll}} &= \tan^{-1}\left(\frac{v_{q,\text{pll}}}{v_{d,\text{pll}}} \right) \tag{1c} \\
-\dot{\delta\theta}_{\text{pll}} &= \Omega_b \delta \omega_{\text{pll}} \tag{1d}
+\dot{\theta}_{\text{pll}} &= \Omega_b \delta \omega_{\text{pll}} \tag{1d}
 \end{align}
 ```
 

--- a/docs/src/component_models/outer_control.md
+++ b/docs/src/component_models/outer_control.md
@@ -14,7 +14,7 @@ uses a simple voltage droop for dispatching reactive power:
 ```math
 \begin{align}
     \dot{\delta\omega}_{\text{olc}} &= \frac{p_{\text{ref}}}{T_a} - \frac{p_e}{T_a} - \frac{k_d(\omega_{\text{olc}} - \omega_{\text{pll}})}{T_a} - \frac{k_\omega(\omega_{\text{olc}} - \omega_{\text{ref}})}{T_a} \tag{1a} \\
-    \dot{\delta\theta}_{\text{olc}} &= \Omega_b \delta\omega_{\text{olc}} \tag{1b} \\
+    \dot{\theta}_{\text{olc}} &= \Omega_b \delta\omega_{\text{olc}} \tag{1b} \\
     \dot{q}_m &= \omega_f (q_e - q_m) \tag{1c}
 \end{align}
 ```

--- a/src/base/simulation_initialization.jl
+++ b/src/base/simulation_initialization.jl
@@ -136,7 +136,7 @@ function _nlsolve_call(
             xtol = tolerance,
             ftol = tolerance,
             method = solver,
-            #autodiff = :forward,
+            autodiff = :forward,
         ) #Solve using initial guess x0
         NLsolveWrapper(sys_solve.zero, NLsolve.converged(sys_solve), false)
     catch e

--- a/src/base/simulation_initialization.jl
+++ b/src/base/simulation_initialization.jl
@@ -102,7 +102,7 @@ function _check_valid_values(initial_guess::Vector{Float64}, inputs::SimulationI
         @error("Invalid initial guess values $invalid_initial_guess")
         return BUILD_FAILED
     end
-    return BUILD_INCOMPLETE
+    return BUILD_FAILED
 end
 
 struct NLsolveWrapper
@@ -115,7 +115,12 @@ NLsolveWrapper() = NLsolveWrapper(Vector{Float64}(), false, true)
 converged(sol::NLsolveWrapper) = sol.converged
 failed(sol::NLsolveWrapper) = sol.failed
 
-function _nlsolve_call(initial_guess, inputs::SimulationInputs, tolerance::Float64)
+function _nlsolve_call(
+    initial_guess,
+    inputs::SimulationInputs,
+    tolerance::Float64,
+    solver::Symbol,
+)
     dx0 = zeros(length(initial_guess)) #Define a vector of zeros for the derivative
     inif! = (out, x) -> system_implicit!(
         out,    #output of the function
@@ -130,8 +135,8 @@ function _nlsolve_call(initial_guess, inputs::SimulationInputs, tolerance::Float
             initial_guess,
             xtol = tolerance,
             ftol = tolerance,
-            method = :trust_region,
-            autodiff = :forward,
+            method = solver,
+            #autodiff = :forward,
         ) #Solve using initial guess x0
         NLsolveWrapper(sys_solve.zero, NLsolve.converged(sys_solve), false)
     catch e
@@ -141,12 +146,14 @@ function _nlsolve_call(initial_guess, inputs::SimulationInputs, tolerance::Float
     end
 end
 
-function _convergence_check(sys_solve::NLsolveWrapper, tol::Float64)
+function _convergence_check(sys_solve::NLsolveWrapper, tol::Float64, solv::Symbol)
     if converged(sys_solve)
-        @info("Initialization succeeded with a tolerance of $(tol). Saving solution")
+        @info(
+            "Initialization succeeded with a tolerance of $(tol) using solver $(solv). Saving solution."
+        )
     else
         @warn(
-            "Initialization convergence failed, initial conditions do not meet conditions for an stable equilibrium.\nTrying to solve again reducing numeric tolerance"
+            "Initialization convergence failed, initial conditions do not meet conditions for an stable equilibrium.\nTrying to solve again reducing numeric tolerance or using another solver"
         )
     end
     return converged(sys_solve)
@@ -160,16 +167,23 @@ function _refine_initial_condition!(
     @debug initial_guess
     converged = false
     for tol in [STRICT_NL_SOLVE_TOLERANCE, RELAXED_NL_SOLVE_TOLERANCE]
-        sys_solve = _nlsolve_call(initial_guess, inputs, tol)
-        failed(sys_solve) && return BUILD_FAILED
-        converged = _convergence_check(sys_solve, tol)
-        @debug "Write result to initial guess vector under condition converged = $(converged)"
-        initial_guess .= sys_solve.zero
         if converged
             break
         end
+        for solv in [:trust_region, :newton]
+            sys_solve = _nlsolve_call(initial_guess, inputs, tol, solv)
+            failed(sys_solve) && return BUILD_FAILED
+            converged = _convergence_check(sys_solve, tol, solv)
+            @debug "Write result to initial guess vector under condition converged = $(converged)"
+            initial_guess .= sys_solve.zero
+            if converged
+                break
+            end
+        end
+    end
+    if !converged
         @warn(
-            "Initialization never converged to desired tolerances. Initial conditions do not meet conditions for an stable equilibrium. Simulation migth diverge"
+            "Initialization never converged to desired tolerances. Initial conditions do not meet conditions for an stable equilibrium. Simulation might diverge"
         )
     end
     return converged ? SIMULATION_INITIALIZED : _check_valid_values(initial_guess, inputs)


### PR DESCRIPTION
The following PR attempts to fix the following issues:
- If the NLsolve call never converged, but it always has finite values, it get stuck in a loop infinitely. This was repaired by changing Line 105 to `BUILD_FAILED`.
- Now we iterate through solvers and tolerances. For the generic renewable models I'm having troubles converging without using newton, so now it tests using `:trust_region` and `:newton`.
- There was a bug about warning after everything fails. The comment about that the Simulation might diverge must be done after passing through all the loop of solvers and tolerances.