### PR TITLE
Small fix to string formatting in check_valid_values

### DIFF
--- a/src/base/simulation_initialization.jl
+++ b/src/base/simulation_initialization.jl
@@ -139,7 +139,7 @@ function check_valid_values(initial_guess::Vector{Float64}, inputs::SimulationIn
         all(isfinite, initial_guess) && continue
         for state in get_global_index(device)
             if state.second ∈ i
-                push!(invalid_initial_guess, "$device - $(p.first)")
+                push!(invalid_initial_guess, "$device - $(state.first)")
             end
         end
     end


### PR DESCRIPTION
Variable `p` is not defined for string formatting in `check_valid_values`.

Is `i` undefined at this point?

https://github.com/rwl/PowerSimulationsDynamics.jl/blob/bc9b33c75d3176933d91a57fa05bf905c5619843/src/base/simulation_initialization.jl#L141