### PR TITLE
add methods for dynamic transformers

### DIFF
--- a/src/base/perturbations.jl
+++ b/src/base/perturbations.jl
@@ -55,6 +55,14 @@ function _get_branch_for_perturbation(
     if perturbation.branch_type == PSY.DynamicBranch
         error("DynamicBranch is not supported currently with perturbation $T")
     end
+
+    if length(PSY.get_components(perturbation.branch_type, sys)) < 1
+        error(
+            "The system does not contain branches type $(perturbation.branch_type). \\
+      If used all_branches_dynamic or all_lines_dynamic make sure the branch $(perturbation.branch_name) was not converted",
+        )
+    end
+
     branch = PSY.get_component(perturbation.branch_type, sys, perturbation.branch_name)
     if branch === nothing || !PSY.get_available(branch)
         throw(
@@ -192,9 +200,9 @@ function ybus_update!(
     Y_l = (1 / (PSY.get_r(b) + PSY.get_x(b) * 1im))
 
     Y11_real = mult * real(Y_l)
-    Y11_imag = mult * imag(Y_l)
+    Y11_imag = mult * imag(Y_l) - PSY.get_primary_shunt(b)
     Y22_real = mult * real(Y_l)
-    Y22_imag = mult * (imag(Y_l) + PSY.get_primary_shunt(b))
+    Y22_imag = mult * imag(Y_l)
     Y12_real = Y21_real = -mult * real(Y_l)
     Y12_imag = Y21_imag = -mult * imag(Y_l)
 
@@ -231,10 +239,10 @@ function ybus_update!(
 
     Y11 = (Y_t * c^2)
     Y21 = Y12 = (-Y_t * c)
-    Y22 = Y_t + (1im * b)
+    Y22 = Y_t
 
     Y11_real = mult * real(Y11)
-    Y11_imag = mult * imag(Y12)
+    Y11_imag = mult * imag(Y12) - b
     Y22_real = mult * real(Y22)
     Y22_imag = mult * imag(Y22)
     Y12_real = -mult * real(Y12)
@@ -280,7 +288,7 @@ function ybus_update!(
     Y22 = Y_t
 
     Y11_real = mult * real(Y11)
-    Y11_imag = mult * imag(Y12)
+    Y11_imag = mult * imag(Y12) - b
     Y22_real = mult * real(Y22)
     Y22_imag = mult * imag(Y22)
     Y12_real = -mult * real(Y12)

--- a/src/base/perturbations.jl
+++ b/src/base/perturbations.jl
@@ -143,7 +143,7 @@ end
 
 function ybus_update!(
     ybus::SparseArrays.SparseMatrixCSC{Float64, Int},
-    b::PSY.ACBranch,
+    b::PSY.Line,
     num_bus::Dict{Int, Int},
     mult::Float64,
 )
@@ -158,6 +158,43 @@ function ybus_update!(
     Y11_imag = mult * (imag(Y_l) + PSY.get_b(b).from)
     Y22_real = mult * real(Y_l)
     Y22_imag = mult * (imag(Y_l) + PSY.get_b(b).to)
+    Y12_real = Y21_real = -mult * real(Y_l)
+    Y12_imag = Y21_imag = -mult * imag(Y_l)
+
+    _record_change!(
+        ybus,
+        bus_from_no,
+        bus_to_no,
+        n_buses,
+        Y11_real,
+        Y11_imag,
+        Y22_real,
+        Y22_imag,
+        Y12_real,
+        Y21_real,
+        Y12_imag,
+        Y21_imag,
+    )
+    return
+end
+
+function ybus_update!(
+    ybus::SparseArrays.SparseMatrixCSC{Float64, Int},
+    b::PSY.Transformer2W,
+    num_bus::Dict{Int, Int},
+    mult::Float64,
+)
+    arc = PSY.get_arc(b)
+    bus_from_no = num_bus[PSY.get_number(arc.from)]
+    bus_to_no = num_bus[arc.to.number]
+    n_buses = length(num_bus)
+
+    Y_l = (1 / (PSY.get_r(b) + PSY.get_x(b) * 1im))
+
+    Y11_real = mult * real(Y_l)
+    Y11_imag = mult * imag(Y_l)
+    Y22_real = mult * real(Y_l)
+    Y22_imag = mult * (imag(Y_l) + PSY.get_primary_shunt(b))
     Y12_real = Y21_real = -mult * real(Y_l)
     Y12_imag = Y21_imag = -mult * imag(Y_l)
 

--- a/src/base/simulation_inputs.jl
+++ b/src/base/simulation_inputs.jl
@@ -314,13 +314,20 @@ function _make_DAE_vector(mass_matrix::AbstractArray, var_count::Int, n_buses::I
     return DAE_vector
 end
 
+function _get_shunt_values(br::PSY.Line)
+    return PSY.get_b(br).from, PSY.get_b(br).to
+end
+
+function _get_shunt_values(::Union{PSY.TapTransformer, PSY.Transformer2W})
+    return 0.0, 0.0
+end
+
 function _make_total_shunts(wrapped_branches, n_buses::Int)
     shunts = SparseArrays.SparseMatrixCSC{Float64, Int}(zeros(2 * n_buses, 2 * n_buses))
     for br in wrapped_branches
         bus_ix_from = get_bus_ix_from(br)
         bus_ix_to = get_bus_ix_to(br)
-        b_from = PSY.get_b(br).from
-        b_to = PSY.get_b(br).to
+        b_from, b_to = _get_shunt_values(br.branch.branch)
         shunts[bus_ix_from, bus_ix_from + n_buses] += b_from
         shunts[bus_ix_to, bus_ix_to + n_buses] += b_to
         shunts[bus_ix_from + n_buses, bus_ix_from] -= b_from

--- a/src/base/simulation_inputs.jl
+++ b/src/base/simulation_inputs.jl
@@ -263,7 +263,7 @@ function _get_ybus(sys::PSY.System)
         lookup = Ybus_.lookup[1]
         ybus_rectangular = transform_ybus_to_rectangular(ybus)
         for br in dyn_lines
-            ybus_update!(ybus_rectangular, br, lookup, -1.0)
+            ybus_update!(ybus_rectangular, br.branch, lookup, -1.0)
         end
     else
         ybus_rectangular =

--- a/src/models/branch.jl
+++ b/src/models/branch.jl
@@ -11,7 +11,7 @@ function branch!(
     current_i_to::AbstractArray{T},
     branch::BranchWrapper,
 ) where {T <: ACCEPTED_REAL_TYPES}
-    mdl_line_ode!(
+    mdl_branch_ode!(
         device_states,
         output_ode,
         voltage_r_from,

--- a/src/models/dynline_model.jl
+++ b/src/models/dynline_model.jl
@@ -1,4 +1,4 @@
-function mdl_line_ode!(
+function mdl_branch_ode!(
     device_states::AbstractArray{T},
     output_ode::AbstractArray{T},
     voltage_r_from::T,
@@ -24,4 +24,39 @@ function mdl_line_ode!(
     current_i_from[1] -= Il_i
     current_r_to[1] += Il_r
     current_i_to[1] += Il_i
+    return
+end
+
+function mdl_transformer_Lshape_ode!(
+    device_states::AbstractArray{T},
+    output_ode::AbstractArray{T},
+    voltage_r_from::T,
+    voltage_i_from::T,
+    voltage_r_to::T,
+    voltage_i_to::T,
+    current_r_from::AbstractArray{T},
+    current_i_from::AbstractArray{T},
+    current_r_to::AbstractArray{T},
+    current_i_to::AbstractArray{T},
+    branch::BranchWrapper,
+) where {T <: ACCEPTED_REAL_TYPES}
+    L = PSY.get_x(branch)
+    R = PSY.get_r(branch)
+    ω_b = get_system_base_frequency(branch) * 2 * π
+
+    shunt = PSY.get_primary_shunt(branch)
+    Il_r = device_states[1]
+    Il_i = device_states[2]
+    Ishunt_r = device_states[3]
+    Ishunt_i = device_states[3]
+    output_ode[1] = (ω_b / L) * ((voltage_r_from - voltage_r_to) - (R * Il_r - L * Il_i))
+    output_ode[2] = (ω_b / L) * ((voltage_i_from - voltage_i_to) - (R * Il_i + L * Il_r))
+    output_ode[3] = (ω_b / shunt) * voltage_i_from + L * Ishunt_i
+    output_ode[4] = (ω_b / shunt) * voltage_i_to - L * Ishunt_r
+
+    current_r_from[1] -= (Il_r + Ishunt_r)
+    current_i_from[1] -= (Il_r + Ishunt_i)
+    current_r_to[1] += Il_r
+    current_i_to[1] += Il_i
+    return
 end

--- a/src/models/dynline_model.jl
+++ b/src/models/dynline_model.jl
@@ -51,8 +51,8 @@ function mdl_transformer_Lshape_ode!(
     Ishunt_i = device_states[3]
     output_ode[1] = (ω_b / L) * ((voltage_r_from - voltage_r_to) - (R * Il_r - L * Il_i))
     output_ode[2] = (ω_b / L) * ((voltage_i_from - voltage_i_to) - (R * Il_i + L * Il_r))
-    output_ode[3] = (ω_b / shunt) * voltage_i_from + L * Ishunt_i
-    output_ode[4] = (ω_b / shunt) * voltage_i_to - L * Ishunt_r
+    output_ode[3] = (ω_b / shunt) * voltage_r_from + L * Ishunt_i
+    output_ode[4] = (ω_b / shunt) * voltage_i_from - L * Ishunt_r
 
     current_r_from[1] -= (Il_r + Ishunt_r)
     current_i_from[1] -= (Il_r + Ishunt_i)


### PR DESCRIPTION
@rodrigomha this PR enables using the same series branch model from the line for the transformers and adds a method to implement in a later stage the L shape model. 

We currently can't implement the L-shape model due to some limitations in `PowerSystems.jl`. This PR requires upstream PSY and PFS PRs merged 