### PR TITLE
Add current post process for ACBranches

### DIFF
--- a/src/post_processing/post_proc_common.jl
+++ b/src/post_processing/post_proc_common.jl
@@ -33,3 +33,24 @@ function get_state_from_ix(global_index::MAPPING_DICT, idx::Int)
     end
     error("State with index $(idx) not found in the global index")
 end
+
+function _obtain_shunt_current(
+    branch::B,
+    V_R_from,
+    V_I_from,
+    V_R_to,
+    V_I_to,
+) where {B <: PSY.Branch}
+    error(
+        "Current branch $(PSY.get_name(branch)) of type $(typeof(branch)) is not supported for this calculation",
+    )
+end
+
+function _obtain_shunt_current(branch::PSY.Line, V_R_from, V_I_from, V_R_to, V_I_to)
+    b_from, b_to = PSY.get_b(branch)
+    z_from = 1.0 / (b_from * 1im)
+    z_to = 1.0 / (b_to * 1im)
+    I_shunt_from = (0.0 - (V_R_from + V_I_from * 1im)) / z_from
+    I_shunt_to = (0.0 - (V_R_to + V_I_to * 1im)) / z_to
+    return real.(I_shunt_from), imag.(I_shunt_from), real.(I_shunt_to), imag.(I_shunt_to)
+end

--- a/test/test_case26_SEXS.jl
+++ b/test/test_case26_SEXS.jl
@@ -77,9 +77,11 @@ function test_sexs_implicit(dyr_file, csv_file, init_cond, eigs_value)
         t = series[1]
         δ = series[2]
         V = series2[2]
-        # TODO: Test Vf with PSSE
+        # TODO: Test Vf with PSSE and power through line in PSSE
         series4 = get_field_voltage_series(results, "generator-102-1")
+        series5 = get_activepower_series(results, "BUS 2-BUS 3-i_1")
         Vf = series4[2]
+        p_line = series5[2]
 
         # TODO: Get PSSE CSV files and enable tests
 

--- a/test/test_case26_SEXS.jl
+++ b/test/test_case26_SEXS.jl
@@ -79,9 +79,7 @@ function test_sexs_implicit(dyr_file, csv_file, init_cond, eigs_value)
         V = series2[2]
         # TODO: Test Vf with PSSE and power through line in PSSE
         series4 = get_field_voltage_series(results, "generator-102-1")
-        series5 = get_activepower_series(results, "BUS 2-BUS 3-i_1")
         Vf = series4[2]
-        p_line = series5[2]
 
         # TODO: Get PSSE CSV files and enable tests
 


### PR DESCRIPTION
This is a temporal solution. We will need a way of dispatching properly once we redo the API.

Note that this method allows to use `get_active_current_series(results, LineName)` to obtain them.

The voltage obtained in `post_proc_voltage_current_series` is taken using the `from` bus, so if you use `get_activepower_series(results, LineName)` it will compute the active power going through the series part of the `ACBranch` measured on the `from` bus.

Closes #224