### PR TITLE
Inverter validation and silent mode

### DIFF
--- a/src/PowerSimulationsDynamics.jl
+++ b/src/PowerSimulationsDynamics.jl
@@ -52,6 +52,7 @@ export get_activepower_branch_flow
 export get_reactivepower_branch_flow
 export get_setpoints
 export get_solution
+export is_valid
 
 ####################################### Package Imports ####################################
 import Logging
@@ -106,6 +107,7 @@ include("base/supplemental_accesors.jl")
 include("base/nlsolve_wrapper.jl")
 include("base/simulation_initialization.jl")
 include("base/small_signal.jl")
+include("base/model_validation.jl")
 
 #Common Models
 include("models/branch.jl")

--- a/src/base/device_wrapper.jl
+++ b/src/base/device_wrapper.jl
@@ -1,16 +1,3 @@
-function isvalid_device(
-    device::PSY.DynamicGenerator{M, S, A, TG, P},
-) where {M <: PSY.Machine, S <: PSY.Shaft, A <: PSY.AVR, TG <: PSY.TurbineGov, P <: PSY.PSS}
-    if M == PSY.BaseMachine && A != PSY.AVRFixed
-        error("Device $(PSY.get_name(device)) uses a BaseMachine model with an AVR")
-    end
-    return
-end
-
-function isvalid_device(::PSY.DynamicInjection)
-    return
-end
-
 get_inner_vars_count(::PSY.DynamicGenerator) = GEN_INNER_VARS_SIZE
 get_inner_vars_count(::PSY.DynamicInverter) = INV_INNER_VARS_SIZE
 get_inner_vars_count(::PSY.PeriodicVariableSource) = 0
@@ -75,7 +62,7 @@ struct DynamicWrapper{T <: PSY.DynamicInjection}
         input_port_mapping::Base.ImmutableDict{Int, Vector{Int}},
         ext::Dict{String, Any},
     ) where {T <: PSY.DynamicInjection}
-        isvalid_device(device)
+        is_valid(device)
 
         new{T}(
             device,

--- a/src/base/jacobian.jl
+++ b/src/base/jacobian.jl
@@ -152,7 +152,7 @@ function get_jacobian(
 ) where {T <: SimulationModel}
     # Deepcopy avoid system modifications
     simulation_system = deepcopy(system)
-    inputs = SimulationInputs(T, simulation_system, ReferenceBus)
+    inputs = SimulationInputs(T, simulation_system, ReferenceBus())
     x0_init = get_flat_start(inputs)
     set_operating_point!(x0_init, inputs, system)
     return get_jacobian(T, inputs, x0_init, sparse_retrieve_loop)

--- a/src/base/model_validation.jl
+++ b/src/base/model_validation.jl
@@ -1,8 +1,8 @@
 # By default all combinations are valid, if a combination of parameters can't be modeled
 # needs to be added here to dispatch on the invalid dynamic component types.
 
-is_valid(::DynamicInverter) = nothing
-is_valid(::DynamicGenerator) = nothing
+is_valid(::PSY.DynamicInverter) = nothing
+is_valid(::PSY.DynamicGenerator) = nothing
 
 function is_valid(
     device::PSY.DynamicGenerator{PSY.BaseMachine, S, PSY.AVRFixed, TG, P},

--- a/src/base/model_validation.jl
+++ b/src/base/model_validation.jl
@@ -1,0 +1,28 @@
+# By default all combinations are valid, if a combination of parameters can't be modeled
+# needs to be added here to dispatch on the invalid dynamic component types.
+
+is_valid(::DynamicInverter) = nothing
+is_valid(::DynamicGenerator) = nothing
+
+function is_valid(
+    device::PSY.DynamicGenerator{PSY.BaseMachine, S, PSY.AVRFixed, TG, P},
+) where {S <: PSY.Shaft, TG <: PSY.TurbineGov, P <: PSY.PSS}
+    error("Device $(PSY.get_name(device)) uses a BaseMachine model with an AVR")
+    return
+end
+
+function is_valid(
+    device::PSY.DynamicInverter{
+        PSY.AverageConverter,
+        PSY.OuterControl{PSY.ActivePowerPI, PSY.ReactivePowerPI},
+        PSY.VoltageModeControl,
+        DC,
+        P,
+        F,
+    },
+) where {DC <: PSY.DCSource, P <: PSY.FrequencyEstimator, F <: PSY.Filter}
+    error(
+        "Device $(PSY.get_name(device)) uses a ActivePowerPI and ReactivePowerPI model with a VoltageModeControl",
+    )
+    return
+end

--- a/src/base/model_validation.jl
+++ b/src/base/model_validation.jl
@@ -5,6 +5,8 @@ is_valid(::PSY.DynamicInverter) = nothing
 is_valid(::PSY.DynamicGenerator) = nothing
 is_valid(::PSY.AggregateDistributedGenerationA) = nothing
 is_valid(::PSY.SimplifiedSingleCageInductionMachine) = nothing
+is_valid(::PSY.PeriodicVariableSource) = nothing
+is_valid(::PSY.SingleCageInductionMachine) = nothing
 
 function is_valid(
     ::PSY.DynamicGenerator{

--- a/src/base/model_validation.jl
+++ b/src/base/model_validation.jl
@@ -7,9 +7,21 @@ is_valid(::PSY.AggregateDistributedGenerationA) = nothing
 is_valid(::PSY.SimplifiedSingleCageInductionMachine) = nothing
 
 function is_valid(
-    device::PSY.DynamicGenerator{PSY.BaseMachine, S, PSY.AVRFixed, TG, P},
-) where {S <: PSY.Shaft, TG <: PSY.TurbineGov, P <: PSY.PSS}
-    error("Device $(PSY.get_name(device)) uses a BaseMachine model with an AVR")
+    ::PSY.DynamicGenerator{
+        PSY.BaseMachine,
+        <:PSY.Shaft,
+        PSY.AVRFixed,
+        <:PSY.TurbineGov,
+        PSY.PSSFixed,
+    },
+)
+    return nothing
+end
+
+function is_valid(
+    device::PSY.DynamicGenerator{PSY.BaseMachine, S, A, TG, P},
+) where {S <: PSY.Shaft, A <: PSY.AVR, TG <: PSY.TurbineGov, P <: PSY.PSS}
+    error("Device $(PSY.get_name(device)) uses a BaseMachine model with an AVR $A")
     return
 end
 

--- a/src/base/model_validation.jl
+++ b/src/base/model_validation.jl
@@ -3,6 +3,8 @@
 
 is_valid(::PSY.DynamicInverter) = nothing
 is_valid(::PSY.DynamicGenerator) = nothing
+is_valid(::PSY.AggregateDistributedGenerationA) = nothing
+is_valid(::PSY.SimplifiedSingleCageInductionMachine) = nothing
 
 function is_valid(
     device::PSY.DynamicGenerator{PSY.BaseMachine, S, PSY.AVRFixed, TG, P},

--- a/src/base/nlsolve_wrapper.jl
+++ b/src/base/nlsolve_wrapper.jl
@@ -23,7 +23,7 @@ function _nlsolve_call(
     jacobian::JacobianFunctionWrapper,
     f_tolerance::Float64,
     solver::Symbol,
-    show_trace::Bool
+    show_trace::Bool,
 )
     df = NLsolve.OnceDifferentiable(
         f_eval,
@@ -49,7 +49,7 @@ function _nlsolve_call(
     f_eval::Function,
     f_tolerance::Float64,
     solver::Symbol,
-    show_trace::Bool
+    show_trace::Bool,
 )
     sys_solve = NLsolve.nlsolve(
         f_eval,
@@ -58,7 +58,7 @@ function _nlsolve_call(
         ftol = f_tolerance,
         iterations = MAX_NLSOLVE_INTERATIONS,
         method = solver,
-        show_trace = show_trace
+        show_trace = show_trace,
     ) # Solve using initial guess x0
     return NLsolveWrapper(sys_solve.zero, NLsolve.converged(sys_solve), false)
 end

--- a/src/base/nlsolve_wrapper.jl
+++ b/src/base/nlsolve_wrapper.jl
@@ -23,6 +23,7 @@ function _nlsolve_call(
     jacobian::JacobianFunctionWrapper,
     f_tolerance::Float64,
     solver::Symbol,
+    show_trace::Bool
 )
     df = NLsolve.OnceDifferentiable(
         f_eval,
@@ -38,7 +39,7 @@ function _nlsolve_call(
         ftol = f_tolerance,
         method = solver,
         iterations = MAX_NLSOLVE_INTERATIONS,
-        show_trace = true,
+        show_trace = show_trace,
     ) # Solve using initial guess x0
     return NLsolveWrapper(sys_solve.zero, NLsolve.converged(sys_solve), false)
 end
@@ -48,6 +49,7 @@ function _nlsolve_call(
     f_eval::Function,
     f_tolerance::Float64,
     solver::Symbol,
+    show_trace::Bool
 )
     sys_solve = NLsolve.nlsolve(
         f_eval,
@@ -56,6 +58,7 @@ function _nlsolve_call(
         ftol = f_tolerance,
         iterations = MAX_NLSOLVE_INTERATIONS,
         method = solver,
+        show_trace = show_trace
     ) # Solve using initial guess x0
     return NLsolveWrapper(sys_solve.zero, NLsolve.converged(sys_solve), false)
 end
@@ -139,8 +142,9 @@ function refine_initial_condition!(
         end
         for solv in [:trust_region, :newton]
             @debug "Start NLSolve System Run with $(solv) and F_tol = $tol"
-            sys_solve = _nlsolve_call(initial_guess, f!, jacobian, tol, solv)
-            #sys_solve = _nlsolve_call(initial_guess, f!, tol, solv)
+            show_trace = sim.console_level <= Logging.Info
+            sys_solve = _nlsolve_call(initial_guess, f!, jacobian, tol, solv, show_trace)
+            #sys_solve = _nlsolve_call(initial_guess, f!, tol, solv, show_trace)
             failed(sys_solve) && return BUILD_FAILED
             converged = _convergence_check(sys_solve, tol, solv)
             @debug "Write initial guess vector using $solv with tol = $tol convergence = $converged"

--- a/src/base/simulation_inputs.jl
+++ b/src/base/simulation_inputs.jl
@@ -125,14 +125,22 @@ end
 """
 SimulationInputs build function for MassMatrixModels
 """
-function SimulationInputs(::Type{MassMatrixModel}, sys::PSY.System, frequency_reference)
+function SimulationInputs(
+    ::Type{MassMatrixModel},
+    sys::PSY.System,
+    frequency_reference::Union{ConstantFrequency, ReferenceBus},
+)
     return SimulationInputs(sys, frequency_reference)
 end
 
 """
 SimulationInputs build function for ResidualModels
 """
-function SimulationInputs(::Type{ResidualModel}, sys::PSY.System, frequency_reference)
+function SimulationInputs(
+    ::Type{ResidualModel},
+    sys::PSY.System,
+    frequency_reference::Union{ConstantFrequency, ReferenceBus},
+)
     return SimulationInputs(sys, frequency_reference)
 end
 

--- a/test/test_base.jl
+++ b/test/test_base.jl
@@ -104,16 +104,15 @@ end
 
         # First run
         @test execute!(sim, IDA(), dtmax = 0.005, saveat = 0.005) ==
-        PSID.SIMULATION_FINALIZED
+              PSID.SIMULATION_FINALIZED
         # Second run
         @test execute!(sim, IDA(), dtmax = 0.005, saveat = 0.005) ==
-        PSID.SIMULATION_FINALIZED
+              PSID.SIMULATION_FINALIZED
     finally
         @info("removing test files")
         rm(path1, force = true, recursive = true)
     end
 end
-
 
 @testset "Hybrid Line Indexing" begin
     ## Create threebus system with more dyn lines ##

--- a/test/test_base.jl
+++ b/test/test_base.jl
@@ -30,6 +30,7 @@ end
             (0.0, 30.0), #time span
             Ybus_change;
             system_to_file = true,
+            console_level = Logging.Error,
         )
         @test sim.status == PSID.BUILT
         # Test accessor functions
@@ -64,6 +65,7 @@ end
             (0.0, 30.0), #time span
             Ybus_change;
             system_to_file = true,
+            console_level = Logging.Error,
         )
         @test sim.status == PSID.BUILT
         m_system = System(joinpath(path2, "initialized_system.json"))
@@ -113,7 +115,13 @@ end
     end
 
     # Tests for all Dynamic Lines
-    sim = Simulation(ResidualModel, threebus_sys_dyns, mktempdir(), (0.0, 10.0))
+    sim = Simulation(
+        ResidualModel,
+        threebus_sys_dyns,
+        mktempdir(),
+        (0.0, 10.0);
+        console_level = Logging.Error,
+    )
     @test sim.status == PSID.BUILT
     sim_inputs = sim.inputs
     DAE_vector = PSID.get_DAE_vector(sim_inputs)
@@ -139,7 +147,13 @@ end
     # Tests for dynamic lines with b = 0
     set_b!(dyn_branch12, (from = 0.0, to = 0.0))
     set_b!(dyn_branch23, (from = 0.0, to = 0.0))
-    sim = Simulation(ResidualModel, threebus_sys_dyns, pwd(), (0.0, 10.0))
+    sim = Simulation(
+        ResidualModel,
+        threebus_sys_dyns,
+        pwd(),
+        (0.0, 10.0);
+        console_level = Logging.Error,
+    )
     @test sim.status == PSID.BUILT
     sim_inputs = sim.inputs
     DAE_vector = PSID.get_DAE_vector(sim_inputs)
@@ -181,6 +195,7 @@ end
         BranchTrip(1.0, Line, "BUS 1-BUS 2-i_1");
         initialize_simulation = false,
         initial_conditions = x0_test,
+        console_level = Logging.Error,
     )
     @test LinearAlgebra.norm(sim.x0_init - x0_test) <= 1e-6
     #Initialize System normally
@@ -189,7 +204,8 @@ end
         sys,
         pwd(),
         (0.0, 20.0),
-        BranchTrip(1.0, Line, "BUS 1-BUS 2-i_1"),
+        BranchTrip(1.0, Line, "BUS 1-BUS 2-i_1");
+        console_level = Logging.Error,
     )
     #Save states without generator at bus 2
     x0 = sim_normal.x0_init
@@ -207,6 +223,7 @@ end
         (0.0, 20.0);
         initialize_simulation = false,
         initial_conditions = x0_no_gen,
+        console_level = Logging.Error,
     )
     @test LinearAlgebra.norm(sim_trip_gen.x0_init - x0_no_gen) <= 1e-6
     #Create Simulation without Gen 2 at steady state
@@ -215,12 +232,19 @@ end
         sys,
         pwd(),
         (0.0, 20.0),
-        BranchTrip(1.0, Line, "BUS 1-BUS 2-i_1"),
+        BranchTrip(1.0, Line, "BUS 1-BUS 2-i_1");
+        console_level = Logging.Error,
     )
     @test length(sim_normal_no_gen.x0_init) == 17
     #Ignore Initial Conditions without passing initialize_simulation = false
-    sim_ignore_init =
-        Simulation(ResidualModel, sys, pwd(), (0.0, 20.0); initial_conditions = x0_no_gen)
+    sim_ignore_init = Simulation(
+        ResidualModel,
+        sys,
+        pwd(),
+        (0.0, 20.0);
+        initial_conditions = x0_no_gen,
+        console_level = Logging.Error,
+    )
     @test LinearAlgebra.norm(sim_ignore_init.x0_init - sim_normal_no_gen.x0_init) <= 1e-6
     #Pass wrong vector size
     x0_wrong = zeros(20)
@@ -230,11 +254,18 @@ end
     #     pwd(),
     #     (0.0, 20.0);
     #     initialize_simulation = false,
-    #     initial_conditions = x0_wrong,
+    #     initial_conditions = x0_wrong;
+    #    console_level = Logging.Error
     # )
     #Flat start initialization
-    sim_flat =
-        Simulation(ResidualModel, sys, pwd(), (0.0, 20.0); initialize_simulation = false)
+    sim_flat = Simulation(
+        ResidualModel,
+        sys,
+        pwd(),
+        (0.0, 20.0);
+        console_level = Logging.Error,
+        initialize_simulation = false,
+    )
     x0_flat = zeros(17)
     x0_flat[1:3] .= 1.0
     @test LinearAlgebra.norm(sim_flat.x0_init - x0_flat) <= 1e-6
@@ -446,7 +477,13 @@ end
     end
 
     # Tests for all Dynamic Lines
-    sim = Simulation(ResidualModel, threebus_sys_dyns, mktempdir(), (0.0, 10.0))
+    sim = Simulation(
+        ResidualModel,
+        threebus_sys_dyns,
+        mktempdir(),
+        (0.0, 10.0);
+        console_level = Logging.Error,
+    )
     global_index = PSID.make_global_state_map(sim.inputs)
     @test_throws ErrorException PSID.get_state_from_ix(global_index, 40)
     @test ("V_2", :R) == PSID.get_state_from_ix(global_index, 2)
@@ -470,7 +507,8 @@ end
         mktempdir(),
         (0.0, 20.0), #time span
         # Not initialized to speed up the test
-        initialize_simulation = false,
+        initialize_simulation = false;
+        console_level = Logging.Error,
     )
 
     @test PSID.get_global_vars_update_pointers(sim.inputs)[1] != 0
@@ -482,7 +520,8 @@ end
         (0.0, 20.0),
         # Not initialized to speed up the test
         initialize_simulation = false,
-        frequency_reference = ConstantFrequency(), #time span
+        frequency_reference = ConstantFrequency(),
+        console_level = Logging.Error, #time span
     )
 
     @test PSID.get_global_vars_update_pointers(sim.inputs)[1] == 0
@@ -514,6 +553,7 @@ end
         mktempdir(),
         (0.0, 30.0); #time span
         all_lines_dynamic = true,
+        console_level = Logging.Error,
     )
     @test sim.status == PSID.BUILT
     inputs = PSID.get_simulation_inputs(sim)
@@ -526,6 +566,7 @@ end
         mktempdir(),
         (0.0, 30.0); #time span
         all_branches_dynamic = true,
+        console_level = Logging.Error,
     )
     @test sim.status == PSID.BUILT
     inputs = PSID.get_simulation_inputs(sim)
@@ -538,6 +579,7 @@ end
         mktempdir(),
         (0.0, 30.0); #time span
         all_lines_dynamic = true,
+        console_level = Logging.Error,
     )
     @test sim.status == PSID.BUILT
     inputs = PSID.get_simulation_inputs(sim)
@@ -585,7 +627,8 @@ end
             omib_sys, #system
             path,
             (0.0, 20.0), #time span
-            Ybus_change,
+            Ybus_change;
+            console_level = Logging.Error,
         )
 
         # Test Initial Condition

--- a/test/test_base.jl
+++ b/test/test_base.jl
@@ -251,7 +251,7 @@ end
     V_i = voltages[3:end]
     ybus_ = PSY.Ybus(omib_sys).data
     I_balance_ybus = -1 * ybus_ * (V_r + V_i .* 1im)
-    inputs = PSID.SimulationInputs(ResidualModel, omib_sys, ConstantFrequency)
+    inputs = PSID.SimulationInputs(ResidualModel, omib_sys, ConstantFrequency())
     I_balance_sim = zeros(4)
     PSID.network_model(inputs, I_balance_sim, voltages)
     for i in 1:2
@@ -280,7 +280,7 @@ end
 
     ybus_original = PSY.Ybus(threebus_sys)
 
-    inputs = PSID.SimulationInputs(ResidualModel, threebus_sys, ConstantFrequency)
+    inputs = PSID.SimulationInputs(ResidualModel, threebus_sys, ConstantFrequency())
 
     for i in 1:3, j in 1:3
         complex_ybus = ybus_original.data[i, j]
@@ -351,7 +351,7 @@ end
     cref = ControlReferenceChange(1.0, mach, :P_ref, 10.0)
     ωref = ControlReferenceChange(1.0, inv, :ω_ref, 0.9)
 
-    inputs = PSID.SimulationInputs(ResidualModel, threebus_sys, ConstantFrequency)
+    inputs = PSID.SimulationInputs(ResidualModel, threebus_sys, ConstantFrequency())
     integrator_for_test = MockIntegrator(inputs)
 
     cref_affect_f = PSID.get_affect(inputs, threebus_sys, cref)
@@ -363,7 +363,7 @@ end
     @test PSID.get_P_ref(inputs.dynamic_injectors[1]) == 10.0
     @test PSID.get_ω_ref(inputs.dynamic_injectors[2]) == 0.9
 
-    inputs = PSID.SimulationInputs(ResidualModel, threebus_sys, ConstantFrequency)
+    inputs = PSID.SimulationInputs(ResidualModel, threebus_sys, ConstantFrequency())
     integrator_for_test = MockIntegrator(inputs)
 
     mach_trip = PSID.GeneratorTrip(1.0, mach)
@@ -403,7 +403,7 @@ end
     load_val = LoadChange(1.0, load_1, :P_ref, 10.0)
     load_trip = LoadTrip(1.0, load_2)
 
-    inputs = PSID.SimulationInputs(ResidualModel, threebus_sys, ConstantFrequency)
+    inputs = PSID.SimulationInputs(ResidualModel, threebus_sys, ConstantFrequency())
     integrator_for_test = MockIntegrator(inputs)
 
     lref_affect_f = PSID.get_affect(inputs, threebus_sys, load_val)
@@ -482,7 +482,7 @@ end
         (0.0, 20.0),
         # Not initialized to speed up the test
         initialize_simulation = false,
-        frequency_reference = ConstantFrequency, #time span
+        frequency_reference = ConstantFrequency(), #time span
     )
 
     @test PSID.get_global_vars_update_pointers(sim.inputs)[1] == 0
@@ -501,7 +501,7 @@ end
     #     (0.0, 20.0),
     #     # Not initialized to speed up the test
     #     initialize_simulation = false,
-    #     frequency_reference = ConstantFrequency, #time span
+    #     frequency_reference = ConstantFrequency(), #time span
     # )
 end
 

--- a/test/test_base.jl
+++ b/test/test_base.jl
@@ -86,6 +86,35 @@ end
     end
 end
 
+@testset "Solve Twice Simulation" begin
+    path1 = (joinpath(pwd(), "test-Base-1"))
+    !isdir(path1) && mkdir(path1)
+    try
+        #Define Simulation Problem
+        sim = Simulation(
+            ResidualModel,
+            omib_sys, #system
+            path1,
+            (0.0, 30.0), #time span
+            Ybus_change;
+            system_to_file = true,
+            console_level = Logging.Error,
+        )
+        @test sim.status == PSID.BUILT
+
+        # First run
+        @test execute!(sim, IDA(), dtmax = 0.005, saveat = 0.005) ==
+        PSID.SIMULATION_FINALIZED
+        # Second run
+        @test execute!(sim, IDA(), dtmax = 0.005, saveat = 0.005) ==
+        PSID.SIMULATION_FINALIZED
+    finally
+        @info("removing test files")
+        rm(path1, force = true, recursive = true)
+    end
+end
+
+
 @testset "Hybrid Line Indexing" begin
     ## Create threebus system with more dyn lines ##
     three_bus_file_dir = joinpath(TEST_FILES_DIR, "data_tests/ThreeBusInverter.raw")


### PR DESCRIPTION
closes #263 
closes #206 -> only prints NLsolve trace if the logging level for console is above Info. 

We need to review the other not allowed combinations, we had some for the REGC_A