### PR TITLE
Mb/post processing frequency

### DIFF
--- a/docs/src/component_models/outer_control.md
+++ b/docs/src/component_models/outer_control.md
@@ -67,7 +67,7 @@ is the point of common coupling.
 ## Active and Reactive Virtual Oscillator Controllers ```[OuterControl]```
 
 The following model represents a Virtual Oscillator Controller for both active and reactive power
-to generate the voltage references that will be used in the Voltage Controller.
+to generate the voltage references that will be used in the Voltage Controller. The contructor is ```OuterControl{ActiveVirtualOscillator, ReactiveVirtualOscillator}```
 It defines a new SRF denoted as ``\theta_{\text{olc}}`` and a voltage reference ``E_{\text{olc}}``.
 The equations are:
 ```math

--- a/src/PowerSimulationsDynamics.jl
+++ b/src/PowerSimulationsDynamics.jl
@@ -50,6 +50,7 @@ export get_real_current_branch_flow
 export get_imaginary_current_branch_flow
 export get_activepower_branch_flow
 export get_reactivepower_branch_flow
+export get_frequency_series
 export get_setpoints
 export get_solution
 

--- a/src/base/simulation_results.jl
+++ b/src/base/simulation_results.jl
@@ -243,6 +243,23 @@ function post_proc_branch_series(
 end
 
 """
+Function to compute the frequency of a Dynamic Injection component.
+"""
+function post_proc_frequency_series(
+    res::SimulationResults,
+    name::String,
+    dt::Union{Nothing, Float64},
+)
+    system = get_system(res)
+    device = PSY.get_component(PSY.StaticInjection, system, name)
+    dyn_device = PSY.get_dynamic_injector(device)
+    if isnothing(dyn_device)
+        error("Dynamic Injection $(name) not found in the system")
+    end
+    ts, ω = compute_frequency(res, dyn_device, dt)
+end
+
+"""
     get_state_series(
         res::SimulationResults,
         ref::Tuple{String, Symbol};
@@ -528,6 +545,23 @@ function get_reactivepower_branch_flow(
         error("The location symbol $(:location) must be :from or :to to specify the bus.")
     end
     return
+end
+
+"""
+    get_frequency_series(
+            res::SimulationResults,
+            name::String,
+    )
+
+Function to obtain the frequency time series of a Dynamic Injection out of the DAE Solution.
+
+# Arguments
+
+- `res::SimulationResults` : Simulation Results object that contains the solution
+- `name::String` : Name to identify the specified device
+"""
+function get_frequency_series(res::SimulationResults, name::String; dt = nothing)
+    return post_proc_frequency_series(res, name, dt)
 end
 
 """

--- a/src/post_processing/post_proc_generator.jl
+++ b/src/post_processing/post_proc_generator.jl
@@ -84,6 +84,20 @@ function compute_mechanical_torque(
 end
 
 """
+Function to obtain the output frequency time series of a DynamicGenerator
+
+"""
+function compute_frequency(
+    res::SimulationResults,
+    dyn_device::G,
+    dt::Union{Nothing, Float64},
+) where {G <: PSY.DynamicGenerator}
+    name = PSY.get_name(dyn_device)
+    ts, ω = post_proc_state_series(res, (name, :ω), dt)
+    return ts, ω
+end
+
+"""
 Function to obtain the output current time series of a Classic Machine model out of the DAE Solution. It is dispatched via the machine type.
 
 """

--- a/test/test_case08_VirtualSynchMachine.jl
+++ b/test/test_case08_VirtualSynchMachine.jl
@@ -74,8 +74,10 @@ Pref_change = ControlReferenceChange(1.0, case_inv, :P_ref, 0.7)
 
         power = PSID.get_activepower_series(results, "generator-102-1")
         rpower = PSID.get_reactivepower_series(results, "generator-102-1")
+        ω2 = PSID.get_frequency_series(results, "generator-102-1")
         @test isa(power, Tuple{Vector{Float64}, Vector{Float64}})
         @test isa(rpower, Tuple{Vector{Float64}, Vector{Float64}})
+        @test isa(ω2, Tuple{Vector{Float64}, Vector{Float64}})
         @test LinearAlgebra.norm(ω - ω_pscad) <= 1e-4
         @test LinearAlgebra.norm(t - round.(t_pscad, digits = 3)) == 0.0
 
@@ -131,11 +133,12 @@ end
 
         power = PSID.get_activepower_series(results, "generator-102-1")
         rpower = PSID.get_reactivepower_series(results, "generator-102-1")
+        ω2 = PSID.get_frequency_series(results, "generator-102-1")
         @test isa(power, Tuple{Vector{Float64}, Vector{Float64}})
         @test isa(rpower, Tuple{Vector{Float64}, Vector{Float64}})
+        @test isa(ω2, Tuple{Vector{Float64}, Vector{Float64}})
         @test LinearAlgebra.norm(ω - ω_pscad) <= 1e-4
         @test LinearAlgebra.norm(t - round.(t_pscad, digits = 3)) == 0.0
-
     finally
         @info("removing test files")
         rm(path, force = true, recursive = true)

--- a/test/test_case15_genrou.jl
+++ b/test/test_case15_genrou.jl
@@ -90,9 +90,11 @@ function test_genrou_implicit(dyr_file, csv_file, init_cond, eigs_value)
 
         power = PSID.get_activepower_series(results, "generator-102-1")
         rpower = PSID.get_reactivepower_series(results, "generator-102-1")
+        ω = PSID.get_frequency_series(results, "generator-102-1")
         @test isa(series2, Tuple{Vector{Float64}, Vector{Float64}})
         @test isa(power, Tuple{Vector{Float64}, Vector{Float64}})
         @test isa(rpower, Tuple{Vector{Float64}, Vector{Float64}})
+        @test isa(ω, Tuple{Vector{Float64}, Vector{Float64}})
     finally
         @info("removing test files")
         rm(path, force = true, recursive = true)
@@ -157,9 +159,11 @@ function test_genrou_mass_matrix(dyr_file, csv_file, init_cond, eigs_value)
 
         power = PSID.get_activepower_series(results, "generator-102-1")
         rpower = PSID.get_reactivepower_series(results, "generator-102-1")
+        ω = PSID.get_frequency_series(results, "generator-102-1")
         @test isa(series2, Tuple{Vector{Float64}, Vector{Float64}})
         @test isa(power, Tuple{Vector{Float64}, Vector{Float64}})
         @test isa(rpower, Tuple{Vector{Float64}, Vector{Float64}})
+        @test isa(ω, Tuple{Vector{Float64}, Vector{Float64}})
     finally
         @info("removing test files")
         rm(path, force = true, recursive = true)

--- a/test/test_case23_droopinverter.jl
+++ b/test/test_case23_droopinverter.jl
@@ -75,6 +75,8 @@ Pref_change = ControlReferenceChange(1.0, case_inv, :P_ref, 0.7)
         @test LinearAlgebra.norm(θ - θ_pscad) <= 3e-2
         @test LinearAlgebra.norm(t - round.(t_pscad, digits = 3)) == 0.0
 
+        ω = PSID.get_frequency_series(results, "generator-102-1")
+        @test isa(ω, Tuple{Vector{Float64}, Vector{Float64}})
     finally
         @info("removing test files")
         rm(path, force = true, recursive = true)
@@ -129,6 +131,8 @@ end
         @test LinearAlgebra.norm(θ - θ_pscad) <= 3e-2
         @test LinearAlgebra.norm(t - round.(t_pscad, digits = 3)) == 0.0
 
+        ω = PSID.get_frequency_series(results, "generator-102-1")
+        @test isa(ω, Tuple{Vector{Float64}, Vector{Float64}})
     finally
         @info("removing test files")
         rm(path, force = true, recursive = true)

--- a/test/test_case24_gridfollowing.jl
+++ b/test/test_case24_gridfollowing.jl
@@ -75,10 +75,12 @@ Pref_change = ControlReferenceChange(1.0, case_inv, :P_ref, 0.7)
         rpower = PSID.get_reactivepower_series(results, "generator-102-1")
         ir = PSID.get_real_current_series(results, "generator-102-1")
         ii = PSID.get_imaginary_current_series(results, "generator-102-1")
+        ω = PSID.get_frequency_series(results, "generator-102-1")
         @test isa(power, Tuple{Vector{Float64}, Vector{Float64}})
         @test isa(rpower, Tuple{Vector{Float64}, Vector{Float64}})
         @test isa(ir, Tuple{Vector{Float64}, Vector{Float64}})
         @test isa(ii, Tuple{Vector{Float64}, Vector{Float64}})
+        @test isa(ω, Tuple{Vector{Float64}, Vector{Float64}})
         @test LinearAlgebra.norm(p - p_pscad) <= 5e-3
         @test LinearAlgebra.norm(t - round.(t_pscad, digits = 3)) == 0.0
 
@@ -136,10 +138,12 @@ end
         rpower = PSID.get_reactivepower_series(results, "generator-102-1")
         ir = PSID.get_real_current_series(results, "generator-102-1")
         ii = PSID.get_imaginary_current_series(results, "generator-102-1")
+        ω = PSID.get_frequency_series(results, "generator-102-1")
         @test isa(power, Tuple{Vector{Float64}, Vector{Float64}})
         @test isa(rpower, Tuple{Vector{Float64}, Vector{Float64}})
         @test isa(ir, Tuple{Vector{Float64}, Vector{Float64}})
         @test isa(ii, Tuple{Vector{Float64}, Vector{Float64}})
+        @test isa(ω, Tuple{Vector{Float64}, Vector{Float64}})
         @test LinearAlgebra.norm(p - p_pscad) <= 5e-3
         @test LinearAlgebra.norm(t - round.(t_pscad, digits = 3)) == 0.0
 

--- a/test/test_case44_voc.jl
+++ b/test/test_case44_voc.jl
@@ -69,8 +69,10 @@ Pref_change = ControlReferenceChange(1.0, case_inv, :P_ref, 0.7)
 
         power = PSID.get_activepower_series(results, "generator-102-1")
         rpower = PSID.get_reactivepower_series(results, "generator-102-1")
+        ω = PSID.get_frequency_series(results, "generator-102-1")
         @test isa(power, Tuple{Vector{Float64}, Vector{Float64}})
         @test isa(rpower, Tuple{Vector{Float64}, Vector{Float64}})
+        @test isa(ω, Tuple{Vector{Float64}, Vector{Float64}})
         #@test LinearAlgebra.norm(ω - ω_pscad) <= 1e-4
         #@test LinearAlgebra.norm(t - round.(t_pscad, digits = 3)) == 0.0
 
@@ -123,8 +125,10 @@ end
 
         power = PSID.get_activepower_series(results, "generator-102-1")
         rpower = PSID.get_reactivepower_series(results, "generator-102-1")
+        ω = PSID.get_frequency_series(results, "generator-102-1")
         @test isa(power, Tuple{Vector{Float64}, Vector{Float64}})
         @test isa(rpower, Tuple{Vector{Float64}, Vector{Float64}})
+        @test isa(ω, Tuple{Vector{Float64}, Vector{Float64}})
         #@test LinearAlgebra.norm(ω - ω_pscad) <= 1e-4
         #@test LinearAlgebra.norm(t - round.(t_pscad, digits = 3)) == 0.0
 


### PR DESCRIPTION
Add `get_frequency_series` for dynamic devices. 
The VOC inverter assumes  `ω_sys = 1.0 ` because `ω_sys` is not available in the simulation result?   