### PR TITLE
remove duplicate initialize_converter!

### DIFF
--- a/src/initialization/init_device.jl
+++ b/src/initialization/init_device.jl
@@ -30,8 +30,6 @@ function initialize_dynamic_device!(
 
     #Initialize Machine and Shaft: V and I
     initialize_filter!(device_states, static, dynamic_device, initial_inner_vars)
-    #Initialize Converter
-    initialize_converter!(device_states, static, dynamic_device, initial_inner_vars)
     #Initialize freq estimator
     initialize_frequency_estimator!(
         device_states,


### PR DESCRIPTION
Tests pass after removing the duplicate call to` initailize_converter!`. I think this might just be a bug?