### PR TITLE
change BusTypes to ACBusTypes

### DIFF
--- a/docs/src/tutorials/tutorial_dynamic_data.md
+++ b/docs/src/tutorials/tutorial_dynamic_data.md
@@ -150,7 +150,7 @@ In order to do so, we will parse the following `ThreebusInverter.raw` network:
 
 ```@repl dyn_data
 threebus_sys = build_system(PSIDSystems, "3 Bus Inverter Base")
-slack_bus = first(get_components(x -> get_bustype(x) == BusTypes.REF, Bus, threebus_sys))
+slack_bus = first(get_components(x -> get_bustype(x) == ACBusTypes.REF, Bus, threebus_sys))
 inf_source = Source(
     name = "InfBus", #name
     available = true, #availability


### PR DESCRIPTION
Hi, this is @yasirroni.

My old account is suspended. I think because I change email to my uni email etc.
___
This fix error on the doc for using `BusTypes`.

But, I don't know which one is better/faster between:

```julia
slack_bus = [b for b in get_components(ACBus, sys) if get_bustype(b) == ACBusTypes.REF][1]
slack_bus = first(get_components(x -> get_bustype(x) == ACBusTypes.REF, Bus, threebus_sys))
```