### PR TITLE
Reset logging level after tutorial

### DIFF
--- a/docs/src/tutorials/tutorial_continuation_pf.jl
+++ b/docs/src/tutorials/tutorial_continuation_pf.jl
@@ -195,10 +195,10 @@ plot!(
     ),
 )
 
-Logging.disable_logging(Logging.Debug); #hide
-
 # This results is consistent with most of the literature for dynamic generator models
 # supplying constant power loads, on which by increasing the active power of the load,
 # produce critical eigenvalues which cross the ``j\omega`` axis at some point. This is
 # called a Hopf Bifurcation, in this case a subcritical one since the limit cycles are
 # unstable.
+
+Logging.disable_logging(Logging.Debug); #hide

--- a/docs/src/tutorials/tutorial_continuation_pf.jl
+++ b/docs/src/tutorials/tutorial_continuation_pf.jl
@@ -23,7 +23,6 @@ gr()
 
 ## Disable Logging to avoid excessive information
 using Logging
-Logging.disable_logging(Logging.Info);
 Logging.disable_logging(Logging.Warn);
 
 # !!! note
@@ -195,6 +194,8 @@ plot!(
         label = "GENROU SSA",
     ),
 )
+
+Logging.disable_logging(Logging.Debug); #hide
 
 # This results is consistent with most of the literature for dynamic generator models
 # supplying constant power loads, on which by increasing the active power of the load,


### PR DESCRIPTION
Minor change to reset logging level after small-signal tutorial. The Power flow loop creates a ton of `Info` statements, so I retained the global disable for the tutorial